### PR TITLE
Fix CSS file not loading in GitHub Pages deployment

### DIFF
--- a/themes/minimal/layouts/_default/baseof.html
+++ b/themes/minimal/layouts/_default/baseof.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
     <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
 </head>
 <body>
     <header>


### PR DESCRIPTION
Use Hugo's relURL function for the stylesheet path instead of a
   hardcoded absolute path. This ensures the CSS file is correctly
   resolved relative to the site's baseURL during deployment.